### PR TITLE
Fix incorrect selector in the settings .cson

### DIFF
--- a/settings/rpm-spec.cson
+++ b/settings/rpm-spec.cson
@@ -13,7 +13,7 @@
 # Please submit bugfixes or comments via
 # https://github.com/waveclaw/language-rpm-spec/issues
 #
-'.source.rpm.spec':
+'.source.rpm-spec':
   'editor':
     'commentStart': '# '
     'completions': [


### PR DESCRIPTION
A single-character diff, yay! :fireworks:

This change makes the whole settings file apply again.

Ctrl+/ makes correct comments again. Tag completions are offered.

Fixes issue #5.
