### PR TITLE
rm lib/language-rpm-spec and adding readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-rpm-spec",
   "readme": "./README.md",
-  "author": "Brenton Horne <brentonhorne77@gmail.com>, JD Powell <waveclaw@hotmail.com>"
+  "author": "Brenton Horne <brentonhorne77@gmail.com>, JD Powell <waveclaw@hotmail.com>",
   "version": "0.9.0",
   "description": "Syntax highlighting for RPM Specfiles",
   "keyswords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-rpm-spec",
-  "main": "./lib/language-rpm-spec",
+  "readme": "./README.md",
   "version": "0.9.0",
   "description": "Syntax highlighting for RPM Specfiles",
   "keyswords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-rpm-spec",
   "readme": "./README.md",
-  "author": "Brenton Horne <brentonhorne77@gmail.com>, JD Powell <waveclaw@hotmail.com>",
+  "author": "JD Powell <waveclaw@hotmail.com>",
   "version": "0.9.0",
   "description": "Syntax highlighting for RPM Specfiles",
   "keyswords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "language-rpm-spec",
   "readme": "./README.md",
+  "author": "Brenton Horne <brentonhorne77@gmail.com>, JD Powell <waveclaw@hotmail.com>"
   "version": "0.9.0",
   "description": "Syntax highlighting for RPM Specfiles",
   "keyswords": [
@@ -14,12 +15,12 @@
     "atom": ">=1.0.0",
     "node": "*"
   },
-  "homepage": "http://atom.github.io",
+  "homepage": "https://atom.io/packages/language-rpm-spec",
   "repository": "https://github.com/waveclaw/language-rpm-spec",
   "bugs": "https://github.com/waveclaw/language-rpm-spec/issues",
   "devDependencies": {
     "coffeelint": "^1.10.1",
-    "coffee-script": "1.7.0"
+    "coffee-script": "^1.8.0"
   },
   "license": "MIT",
   "dependencies": {}


### PR DESCRIPTION
Hi,

`lib/language-rpm-spec` does not exist. Also good practice to include a reference to the README in the package.json, which I am doing in this pull request. Please `apm publish patch` after merging this pull request, so that this fix becomes available to those of us that use this package. 

Thanks for your time,
Brenton
