### PR TITLE
Update architectures patterns

### DIFF
--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|s390|armv6l|armv7l|aarch64|alpha|sparc64)',
+            'match': '(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|armv6l|armv7l|aarch64)',
+            'match': '(?:s390x|s390|armv6l|armv7l|aarch64)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64)',
+            'match': '(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -250,7 +250,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:ppc64p7|ppc64leppc64|ppc)',
+            'match': '(?:ppc64p7|ppc64le|ppc64|ppc)',
             'name': 'constant.language.rpm-spec'
         }
 

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9)',
+            'match': '(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9|sparc)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|s390|armv6l|armv7l|aarch64)',
+            'match': '(?:s390x|s390|armv6l|armv7l|aarch64|alpha)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -242,7 +242,7 @@
   'architectures':
     'patterns': [
         {
-            'match': '(?:noarch|i386|i586|x86_64|local)',
+            'match': '(?:noarch|i386|i586|x86_64|ia64|local)',
             'name': 'constant.language.rpm-spec'
         }
         {

--- a/grammars/rpm-spec.cson
+++ b/grammars/rpm-spec.cson
@@ -246,7 +246,7 @@
             'name': 'constant.language.rpm-spec'
         }
         {
-            'match': '(?:s390x|s390|armv6l|armv7l|aarch64|alpha)',
+            'match': '(?:s390x|s390|armv6l|armv7l|aarch64|alpha|sparc64)',
             'name': 'constant.language.rpm-spec'
         }
         {


### PR DESCRIPTION
This pull request fixes ppc64le and ppc64 patterns, and add new patterns for some missing architectures (s390, ia64, alpha, sparc64, armv7hl, sparcv9, sparc).