### PR TITLE
Remove duplicate snippet key

### DIFF
--- a/snippets/rpm-spec.cson
+++ b/snippets/rpm-spec.cson
@@ -42,7 +42,6 @@
       %install
       %{__make} install DESTDIR=%{buildroot} %{?_smp_mflags}
     """
-'.source.rpm-spec':
   'changelog entry':
     'prefix': 'chi'
     'body': """

--- a/spec/rpm-spec-spec.coffee
+++ b/spec/rpm-spec-spec.coffee
@@ -27,10 +27,6 @@ describe 'RPMSpec grammar', ->
     runs ->
       grammar = atom.grammars.grammarForScopeName('source.rpm-spec')
 
-  afterEach ->
-    atom.packages.deactivatePackages()
-    atom.packages.unloadPackages()
-
   it 'parses the grammar', ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe 'source.rpm-spec'


### PR DESCRIPTION
This package has a duplicate snippet (`.source.rpm-spec`), which has started causing breakage in [Atom v1.25.0](https://github.com/atom/atom/releases/tag/v1.25.0).

Duplicate snippet keys are now considered an error — see [`atom/snippets#250`](https://github.com/atom/snippets/pull/250) for more info.

I recommend tagging and publishing a patch release after this has been merged.