### PR TITLE
changelogs grammar: Don't require @ in email

### DIFF
--- a/grammars/rpm-changelogs.cson
+++ b/grammars/rpm-changelogs.cson
@@ -36,7 +36,7 @@
   }
 # SuSE Open Build Service .changes files
   {
-    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+ \\d+:\\d+:\\d+ [A-Z]+ \\d{4}) - (.*) (<.*@.*>) ([#_a-zA-Z0-9.-]+)$',
+    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+ \\d+:\\d+:\\d+ [A-Z]+ \\d{4}) - (.*) (<.*>) ([#_a-zA-Z0-9.-]+)$',
     'captures':
       '1':
           'name': 'constant.changelogs'
@@ -49,7 +49,7 @@
   }
 # GNU Type II changelogs
   {
-    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+(?: \\d+:\\d+:\\d+ [A-Z]+)? \\d{4}) (.*) (<.+@.+>)(?: -)? ([#a-zA-Z0-9.-]+)?$',
+    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+(?: \\d+:\\d+:\\d+ [A-Z]+)? \\d{4}) (.*) (<.*>)(?: -)? ([#a-zA-Z0-9.-]+)?$',
     'captures':
       '1':
           'name': 'constant.changelogs'
@@ -62,7 +62,7 @@
   }
 # RedHat New Style changelogs
   {
-    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+(?: \\d+:\\d+:\\d+ [A-Z]+)? \\d{4}) (.*) (<.*@.*>)(?: -) (.*)$',
+    'match': '^(?:\\* )?([a-zA-Z]{3} [a-zA-Z]{3}[ ]+\\d+(?: \\d+:\\d+:\\d+ [A-Z]+)? \\d{4}) (.*) (<.*>)(?: -) (.*)$',
     'captures':
       '1':
           'name': 'constant.changelogs'


### PR DESCRIPTION
Obfuscated email addresses such as "`user AT gmail dot com`" currently break the changelog grammar (disabling syntax highlighting on the line), since the grammar expects an `@` sign in the address.

Some changelog formats have the address surrounded by angle brackets, so requiring the `@` is overkill. In those formats we can accept any `(<.*>)` as an email address.

After:
![image](https://user-images.githubusercontent.com/538020/49853720-0552fc80-fdb6-11e8-8566-5fba7c8ee84c.png)
